### PR TITLE
feat(datadog): add profile env and prompt integration

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -15,6 +15,26 @@ p6df::modules::datadog::deps() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::datadog::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#>
+######################################################################
+p6df::modules::datadog::init() {
+  local _module="$1"
+  local dir="$2"
+
+  p6_bootstrap "$dir"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::datadog::langs()
 #
 #>
@@ -43,6 +63,97 @@ p6df::modules::datadog::langs() {
 p6df::modules::datadog::clones() {
 
   p6_github_cli_parallel_clone DataDog "$P6_DFZ_SRC_FOCUSED_DIR"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: str str = p6df::modules::datadog::prompt::mod()
+#
+#  Returns:
+#	str - str
+#
+#  Environment:	 DATADOG_API_KEY DATADOG_APP_KEY DATADOG_SITE P6_DFZ_PROFILE_DATADOG
+#>
+######################################################################
+p6df::modules::datadog::prompt::mod() {
+  local str=""
+  if p6_string_blank_NOT "$P6_DFZ_PROFILE_DATADOG"; then
+    str="datadog:\t  $P6_DFZ_PROFILE_DATADOG:"
+    if p6_string_blank_NOT "$DATADOG_SITE"; then
+      str=$(p6_string_append "$str" "$DATADOG_SITE" " ")
+    fi
+    if p6_string_blank_NOT "$DATADOG_API_KEY"; then
+      str=$(p6_string_append "$str" "api" "/")
+    fi
+    if p6_string_blank_NOT "$DATADOG_APP_KEY"; then
+      str=$(p6_string_append "$str" "app" "/")
+    fi
+  fi
+
+  p6_return_str "$str"
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::datadog::profile::on(profile, env)
+#
+#  Args:
+#	profile -
+#	env -
+#
+#  Environment:	 P6_DFZ_PROFILE_DATADOG
+#>
+######################################################################
+p6df::modules::datadog::profile::on() {
+  local profile="$1"
+  local env="$2"
+
+  p6_run_code "$env"
+  p6_env_export "P6_DFZ_PROFILE_DATADOG" "$profile"
+
+  # Support common DD_* aliases while keeping DATADOG_* canonical.
+  if p6_string_blank "$DATADOG_API_KEY" && p6_string_blank_NOT "$DD_API_KEY"; then
+    p6_env_export "DATADOG_API_KEY" "$DD_API_KEY"
+  fi
+  if p6_string_blank "$DATADOG_APP_KEY" && p6_string_blank_NOT "$DD_APP_KEY"; then
+    p6_env_export "DATADOG_APP_KEY" "$DD_APP_KEY"
+  fi
+  if p6_string_blank "$DATADOG_SITE"; then
+    p6_env_export "DATADOG_SITE" "datadoghq.com"
+  fi
+  if p6_string_blank "$DD_API_KEY" && p6_string_blank_NOT "$DATADOG_API_KEY"; then
+    p6_env_export "DD_API_KEY" "$DATADOG_API_KEY"
+  fi
+  if p6_string_blank "$DD_APP_KEY" && p6_string_blank_NOT "$DATADOG_APP_KEY"; then
+    p6_env_export "DD_APP_KEY" "$DATADOG_APP_KEY"
+  fi
+  if p6_string_blank "$DD_SITE" && p6_string_blank_NOT "$DATADOG_SITE"; then
+    p6_env_export "DD_SITE" "$DATADOG_SITE"
+  fi
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::datadog::profile::off()
+#
+#  Environment:	 DATADOG_API_KEY DATADOG_APP_KEY DATADOG_SITE DD_API_KEY DD_APP_KEY DD_SITE P6_DFZ_PROFILE_DATADOG
+#>
+######################################################################
+p6df::modules::datadog::profile::off() {
+  p6_env_export_un P6_DFZ_PROFILE_DATADOG
+  p6_env_export_un DATADOG_API_KEY
+  p6_env_export_un DATADOG_APP_KEY
+  p6_env_export_un DATADOG_SITE
+  p6_env_export_un DD_API_KEY
+  p6_env_export_un DD_APP_KEY
+  p6_env_export_un DD_SITE
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary
- add module init bootstrap
- add datadog profile on/off using env code
- add prompt module output for datadog profile and key presence
- support DATADOG_* and DD_* env aliases

## Validation
- zsh -n init.zsh
- Datadog API validate endpoint returned valid=true with configured key