### PR TITLE
feat: add mcp() hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Datadog: multi-language SDK installs, profile switching
+(`DATADOG_API_KEY`, `DD_API_KEY`, `DD_SITE`), and MCP server
+(`datadog-mcp-server`) for AI-driven observability queries.
 
 ## Contributing
 
@@ -37,16 +39,28 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::datadog::clones()`
 - `p6df::modules::datadog::deps()`
+- `p6df::modules::datadog::init(_module, dir)`
+  - Args:
+    - _module
+    - dir
 - `p6df::modules::datadog::langs()`
+- `p6df::modules::datadog::mcp()`
+- `p6df::modules::datadog::profile::off()`
+- `p6df::modules::datadog::profile::on(profile, env)`
+  - Args:
+    - profile
+    - env
+- `str str = p6df::modules::datadog::prompt::mod()`
 
 ## Hierarchy
 
 ```text
 .
 ├── init.zsh
+├── lib
 └── README.md
 
-1 directory, 2 files
+2 directories, 2 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -105,7 +105,7 @@ p6df::modules::datadog::prompt::mod() {
 #	profile -
 #	env -
 #
-#  Environment:	 P6_DFZ_PROFILE_DATADOG
+#  Environment:	 DATADOG_API_KEY DATADOG_APP_KEY DATADOG_SITE DD_API_KEY DD_APP_KEY DD_SITE P6_DFZ_PROFILE_DATADOG
 #>
 ######################################################################
 p6df::modules::datadog::profile::on() {
@@ -154,6 +154,20 @@ p6df::modules::datadog::profile::off() {
   p6_env_export_un DD_API_KEY
   p6_env_export_un DD_APP_KEY
   p6_env_export_un DD_SITE
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::datadog::mcp()
+#
+#>
+######################################################################
+p6df::modules::datadog::mcp() {
+
+  p6_js_npm_global_install "datadog-mcp-server"
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Add `mcp()` hook: installs `datadog-mcp-server` for AI-driven Datadog observability (metrics, logs, dashboards, monitors) via MCP
- Profile already sets `DD_API_KEY`/`DD_APP_KEY`/`DD_SITE` — no `mcp::env()` needed

## Test plan

- [ ] `p6df mcp` installs `datadog-mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)