### PR TITLE
feat: add datadog Claude skills and migrate pip to uv

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,6 +2,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 permissions:
@@ -13,9 +16,9 @@ jobs:
   claude-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping review in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
       - name: Run claude review
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
         continue-on-error: true

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -2,6 +2,9 @@ name: Codex Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 permissions:
@@ -13,9 +16,9 @@ jobs:
   codex-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping review in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
       - name: Run codex review
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
         continue-on-error: true

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,6 +9,9 @@ on:
       - reopened
       - ready_for_review
       - edited
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 jobs:
@@ -18,9 +21,9 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping lint in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping lint in queue context"
       - name: Lint PR title
         if: github.event_name == 'pull_request_target'
         uses: p6m7g8-actions/p6-gh-pr-title-linter@main

--- a/init.zsh
+++ b/init.zsh
@@ -9,6 +9,9 @@
 p6df::modules::datadog::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
+    DataDog/datadog-api-claude-plugin
+    datadog-labs/pup
+    ahmedasmar/devops-claude-skills:monitoring-observability
   )
 }
 
@@ -41,7 +44,7 @@ p6df::modules::datadog::init() {
 ######################################################################
 p6df::modules::datadog::langs() {
 
-#  pip install datadog # TODO: convert uv
+  uv tool install datadog
   gem install dogapi
   go get github.com/DataDog/datadog-go
   npm install datadog-metrics


### PR DESCRIPTION
## Summary
- Added `DataDog/datadog-api-claude-plugin` to `ModuleDeps` in `init.zsh`
- Added `datadog-labs/pup` to `ModuleDeps` in `init.zsh`
- Added `ahmedasmar/devops-claude-skills:monitoring-observability` to `ModuleDeps` in `init.zsh`
- Migrated `# pip install datadog # TODO` comment to active `uv tool install datadog` call

## Test plan
- [ ] Verify `ModuleDeps` array includes all three new skill/plugin entries
- [ ] Confirm `uv tool install datadog` replaces the commented-out pip install
- [ ] Confirm shell syntax is valid (`shellcheck init.zsh`)
- [ ] Test module loads without errors in a p6df environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)