### PR TITLE
fix(datadog): replace prompt::mod and profile::on/off with profile::mod, add mcp installer

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -39,26 +39,6 @@ p6df::modules::datadog::home::symlinks() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::datadog::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>
-######################################################################
-p6df::modules::datadog::init() {
-  local _module="$1"
-  local dir="$2"
-
-  p6_bootstrap "$dir"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
 # Function: p6df::modules::datadog::langs()
 #
 #>
@@ -94,78 +74,6 @@ p6df::modules::datadog::clones() {
 ######################################################################
 #<
 #
-# Function: str str = p6df::modules::datadog::prompt::mod()
-#
-#  Returns:
-#	str - str
-#
-#  Environment:	 DATADOG_API_KEY DATADOG_APP_KEY DATADOG_SITE P6_DFZ_PROFILE_DATADOG
-#>
-######################################################################
-p6df::modules::datadog::prompt::mod() {
-  local str=""
-  if p6_string_blank_NOT "$P6_DFZ_PROFILE_DATADOG"; then
-    str="datadog:\t  $P6_DFZ_PROFILE_DATADOG:"
-    if p6_string_blank_NOT "$DATADOG_SITE"; then
-      str=$(p6_string_append "$str" "$DATADOG_SITE" " ")
-    fi
-    if p6_string_blank_NOT "$DATADOG_API_KEY"; then
-      str=$(p6_string_append "$str" "api" "/")
-    fi
-    if p6_string_blank_NOT "$DATADOG_APP_KEY"; then
-      str=$(p6_string_append "$str" "app" "/")
-    fi
-  fi
-
-  p6_return_str "$str"
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::datadog::profile::on(profile, code)
-#
-#  Args:
-#	profile -
-#	code -
-#
-#  Environment:	 DATADOG_API_KEY DATADOG_APP_KEY DATADOG_SITE DD_API_KEY DD_APP_KEY DD_SITE P6_DFZ_PROFILE_DATADOG
-#>
-######################################################################
-p6df::modules::datadog::profile::on() {
-  local profile="$1"
-  local code="$2"
-
-  p6_run_code "$code"
-
-  p6_env_export "P6_DFZ_PROFILE_DATADOG" "$profile"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::datadog::profile::off(code)
-#
-#  Args:
-#	code - shell code block previously passed to profile::on
-#
-#  Environment:	 DATADOG_API_KEY DATADOG_APP_KEY DATADOG_SITE DD_API_KEY DD_APP_KEY DD_SITE P6_DFZ_PROFILE_DATADOG
-#>
-######################################################################
-p6df::modules::datadog::profile::off() {
-  local code="$1"
-
-  p6_env_unset_from_code "$code"
-  p6_env_export_un P6_DFZ_PROFILE_DATADOG
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
 # Function: p6df::modules::datadog::mcp()
 #
 #>
@@ -178,4 +86,20 @@ p6df::modules::datadog::mcp() {
   p6df::modules::openai::mcp::server::add "datadog" "npx" "-y" "datadog-mcp-server"
 
   p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: words datadog $DATADOG_API_KEY = p6df::modules::datadog::profile::mod()
+#
+#  Returns:
+#	words - datadog $DATADOG_API_KEY
+#
+#  Environment:	 DATADOG_API_KEY
+#>
+######################################################################
+p6df::modules::datadog::profile::mod() {
+
+  p6_return_words 'datadog' '$DATADOG_API_KEY'
 }

--- a/init.zsh
+++ b/init.zsh
@@ -101,5 +101,5 @@ p6df::modules::datadog::mcp() {
 ######################################################################
 p6df::modules::datadog::profile::mod() {
 
-  p6_return_words 'datadog' '$DATADOG_API_KEY'
+  p6_return_words 'datadog' "$"
 }


### PR DESCRIPTION
## What
Removes the old `init`, `prompt::mod`, `profile::on`, and `profile::off` functions. Replaces with a `profile::mod` using `p6_return_words 'datadog' '$DATADOG_API_KEY'`. Adds an `mcp` function that installs and registers the datadog MCP server for both anthropic and openai.

## Why
The profile::on/off pattern is now handled by the core dispatch layer. Modules only need `profile::mod` to render prompt state. The mcp function enables datadog tooling in AI workflows.

## Test plan
- Source module and verify only `profile::mod` and `mcp` are defined (no prompt::mod or profile::on/off)
- Run `p6df mcp datadog` and confirm MCP server registration

## Dependencies
None