### PR TITLE
feat(profile): add DATADOG_SITE and DATADOG_API_KEY to profile mod

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -101,5 +101,5 @@ p6df::modules::datadog::mcp() {
 ######################################################################
 p6df::modules::datadog::profile::mod() {
 
-  p6_return_words 'datadog' "$"
+  p6_return_words 'datadog' '$DATADOG_SITE' '$DATADOG_API_KEY' 
 }

--- a/init.zsh
+++ b/init.zsh
@@ -91,12 +91,12 @@ p6df::modules::datadog::mcp() {
 ######################################################################
 #<
 #
-# Function: words datadog $DATADOG_API_KEY = p6df::modules::datadog::profile::mod()
+# Function: words datadog $DATADOG_SITE $DATADOG_API_KEY = p6df::modules::datadog::profile::mod()
 #
 #  Returns:
-#	words - datadog $DATADOG_API_KEY
+#	words - datadog $DATADOG_SITE $DATADOG_API_KEY
 #
-#  Environment:	 DATADOG_API_KEY
+#  Environment:	 DATADOG_SITE DATADOG_API_KEY
 #>
 ######################################################################
 p6df::modules::datadog::profile::mod() {


### PR DESCRIPTION
## What
Add `$DATADOG_SITE` and `$DATADOG_API_KEY` to the `p6df::modules::datadog::profile::mod` return value.

## Why
The profile mod was returning only the module name with a bare `"$"` placeholder. This populates it with the actual Datadog env vars needed for API access and MCP integration.

## Test plan
- Reviewed diff; change is a one-line string replacement in `init.zsh`
- No functional logic changed, only the return value of the profile mod function

## Dependencies
None