### PR TITLE
fix(profile): simplify profile::mod return signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@
 
 ## Summary
 
-p6df module for Datadog: multi-language SDK installs, profile switching
-(`DATADOG_API_KEY`, `DD_API_KEY`, `DD_SITE`), and MCP server
-(`datadog-mcp-server`) for AI-driven observability queries.
+TODO: Add a short summary of this module.
 
 ## Contributing
 
@@ -39,18 +37,10 @@ p6df module for Datadog: multi-language SDK installs, profile switching
 
 - `p6df::modules::datadog::clones()`
 - `p6df::modules::datadog::deps()`
-- `p6df::modules::datadog::init(_module, dir)`
-  - Args:
-    - _module
-    - dir
+- `p6df::modules::datadog::home::symlinks()`
 - `p6df::modules::datadog::langs()`
 - `p6df::modules::datadog::mcp()`
-- `p6df::modules::datadog::profile::off()`
-- `p6df::modules::datadog::profile::on(profile, env)`
-  - Args:
-    - profile
-    - env
-- `str str = p6df::modules::datadog::prompt::mod()`
+- `words datadog = p6df::modules::datadog::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -91,12 +91,12 @@ p6df::modules::datadog::mcp() {
 ######################################################################
 #<
 #
-# Function: words datadog $DATADOG_SITE $DATADOG_API_KEY = p6df::modules::datadog::profile::mod()
+# Function: words datadog = p6df::modules::datadog::profile::mod()
 #
 #  Returns:
-#	words - datadog $DATADOG_SITE $DATADOG_API_KEY
+#	words - datadog
 #
-#  Environment:	 DATADOG_SITE DATADOG_API_KEY
+#  Environment:	 DATADOG_API_KEY DATADOG_SITE
 #>
 ######################################################################
 p6df::modules::datadog::profile::mod() {


### PR DESCRIPTION
**What:** Remove env vars from `profile::mod` return signature, returning only the module name word.

**Why:** Aligns with the updated `p6_return_words` convention where env vars are documented via the Environment section rather than encoded in the return value.

**Test plan:** Manual shell reload verification; no functional behavior change.

**Dependencies:** none